### PR TITLE
Add a sort-by hyper

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -2034,6 +2034,10 @@ hypers = {
 		arity = link.arity,
 		call = lambda x, y = None: [variadic_link(link, (t, y)) for t in iterable(x, make_range = True)]
 	),
+	'Þ': lambda link, none = None: attrdict(
+		arity = 1,
+		call = lambda x: sorted(x, key=lambda t: monadic_link(link, t))
+	),
 	'Ð€': lambda link, none = None: attrdict(
 		arity = link.arity,
 		call = lambda x, y = None: [variadic_link(link, (x, t)) for t in iterable(y, make_range = True)]


### PR DESCRIPTION
`Þ` takes a link _f_ and returns a new monadic link that performs a stable sort using monadic application of _f_ as key. For example, `LÞ` sorts a list by length (ascending):

```
“this is a new sorting hyper”ṣ⁶LÞj⁶
```

prints

```
a is new this hyper sorting
```
