### PR TITLE
Add char-pair literals

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -548,7 +548,7 @@ def parse_code(code):
 
 def parse_literal(literal_match):
 	literal = literal_match.group(0)
-	if literal[0] == '”':
+	if literal[0] in '”⁽⁾':
 		return repr(literal[1:])
 	elif literal[0] == '“':
 		if literal[-1] in '«»‘’”':
@@ -2210,11 +2210,13 @@ hypers = {
 
 str_arities = 'øµð'
 str_strings = '“[^«»‘’”]*[«»‘’”]?'
+str_ascistr = '⁽[ -~]*'
 str_charlit = '”.'
+str_chrpair = '⁾..'
 str_realdec = '(?:0|-?\d*\.\d*|-?\d+|-)'
 str_realnum = str_realdec.join(['(?:', '?ȷ', '?|', ')'])
 str_complex = str_realnum.join(['(?:', '?ı', '?|', ')'])
-str_literal = '(?:' + str_strings + '|' + str_charlit + '|' + str_complex + ')'
+str_literal = '(?:%s)' % '|'.join([str_strings, str_ascistr, str_charlit, str_chrpair])
 str_litlist = '\[*' + str_literal + '(?:(?:\]*,\[*)' + str_literal + ')*' + '\]*'
 str_nonlits = '|'.join(map(re.escape, list(atoms) + list(quicks) + list(hypers)))
 

--- a/jelly.py
+++ b/jelly.py
@@ -548,7 +548,7 @@ def parse_code(code):
 
 def parse_literal(literal_match):
 	literal = literal_match.group(0)
-	if literal[0] in '”⁽⁾':
+	if literal[0] in '”⁾':
 		return repr(literal[1:])
 	elif literal[0] == '“':
 		if literal[-1] in '«»‘’”':
@@ -2210,13 +2210,12 @@ hypers = {
 
 str_arities = 'øµð'
 str_strings = '“[^«»‘’”]*[«»‘’”]?'
-str_ascistr = '⁽[ -~]*'
 str_charlit = '”.'
 str_chrpair = '⁾..'
 str_realdec = '(?:0|-?\d*\.\d*|-?\d+|-)'
 str_realnum = str_realdec.join(['(?:', '?ȷ', '?|', ')'])
 str_complex = str_realnum.join(['(?:', '?ı', '?|', ')'])
-str_literal = '(?:%s)' % '|'.join([str_strings, str_ascistr, str_charlit, str_chrpair, str_complex])
+str_literal = '(?:%s)' % '|'.join([str_strings, str_charlit, str_chrpair, str_complex])
 str_litlist = '\[*' + str_literal + '(?:(?:\]*,\[*)' + str_literal + ')*' + '\]*'
 str_nonlits = '|'.join(map(re.escape, list(atoms) + list(quicks) + list(hypers)))
 

--- a/jelly.py
+++ b/jelly.py
@@ -2216,7 +2216,7 @@ str_chrpair = '⁾..'
 str_realdec = '(?:0|-?\d*\.\d*|-?\d+|-)'
 str_realnum = str_realdec.join(['(?:', '?ȷ', '?|', ')'])
 str_complex = str_realnum.join(['(?:', '?ı', '?|', ')'])
-str_literal = '(?:%s)' % '|'.join([str_strings, str_ascistr, str_charlit, str_chrpair])
+str_literal = '(?:%s)' % '|'.join([str_strings, str_ascistr, str_charlit, str_chrpair, str_complex])
 str_litlist = '\[*' + str_literal + '(?:(?:\]*,\[*)' + str_literal + ')*' + '\]*'
 str_nonlits = '|'.join(map(re.escape, list(atoms) + list(quicks) + list(hypers)))
 


### PR DESCRIPTION
`⁽` strings eat up all characters in the space-through-tilde ASCII range:

```
    $ ./jelly eun ⁽HelloṚ
olleH
```

`⁾` strings are two characters long:

```
    $ ./jelly eun ⁾abx5
aaaaabbbbb
```
