### PR TITLE
Base Decompression, ṃ

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -2,7 +2,7 @@ import cmath, copy, dictionary, fractions, functools, itertools, locale, math, n
 
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
-# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƤƬƲȤɓɗƒɦƙɱɲƥʠɼʂƭʋȥẸẈẒĿṘẎŻẹḥḳṃṇọụṿẉỵẓḋėġŀṅẏ
+# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƤƬƲȤɓɗƒɦƙɱɲƥʠɼʂƭʋȥẸẈẒĿṘẎŻẹḥḳṇọụṿẉỵẓḋėġŀṅẏ
 
 str_digit = '0123456789'
 str_lower = 'abcdefghijklmnopqrstuvwxyz'
@@ -29,6 +29,10 @@ def at_index(index, array):
 	if low_index == high_index:
 		return array[low_index % len(array)]
 	return [array[low_index % len(array)], array[high_index % len(array)]]
+
+def base_decompression(integer, digits):
+	digits = iterable(digits, make_range=True)
+	return [digits[i-1] for i in to_base(integer, len(digits))]
 
 def bounce(array):
 	return array[:-1] + array[::-1]
@@ -1328,6 +1332,10 @@ atoms = {
 	'ṁ': attrdict(
 		arity = 2,
 		call = lambda x, y: mold(iterable(x, make_copy = True), iterable(y, make_copy = True, make_range = True))
+	),
+	'ṃ': attrdict(
+		arity = 2,
+		call = base_decompression
 	),
 	'N': attrdict(
 		arity = 1,


### PR DESCRIPTION
Dyad `ṃ` expecting an integer and an iterable. Evaluates the integer in base `len(iterable)` then 1-based-indexes into the same iterable. For non-negative integers the iterable gives the digits of a base `[1,2,...,0]` into which to convert the number (it still does for negatives, but indexing will then be `[-n,-n+1,...,0]`. The iterable may be a number, in which case a range will be made - giving base digits `[1,2,...N]`, so `9999ṃ7` is equivalent to `9999b7o7`