### PR TITLE
Add integer pair literal, `⁽`

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -632,6 +632,9 @@ def parse_literal(literal_match):
 			parsed = [[string] if len(string) == 1 else string for string in parsed]
 		if len(parsed) == 1:
 			parsed = parsed[0]
+	elif literal[0] == '⁽':
+		parsed = from_base([code_page.find(char) + 1 for char in literal[1:]], 250)
+		parsed += parsed > 31500 and -62850 or 750
 	else:
 		parsed = eval('+ 1j *'.join([
 			repr(eval('* 10 **'.join(['-1' if part == '-' else (part + '5' if part[-1:] == '.' else part) or repr(2 * index + 1)
@@ -2504,10 +2507,11 @@ str_arities = 'øµð'
 str_strings = '“[^«»‘’”]*[«»‘’”]?'
 str_charlit = '”.'
 str_chrpair = '⁾..'
+str_intpair = '⁽..'
 str_realdec = '(?:0|-?\d*\.\d*|-?\d+|-)'
 str_realnum = str_realdec.join(['(?:', '?ȷ', '?|', ')'])
 str_complex = str_realnum.join(['(?:', '?ı', '?|', ')'])
-str_literal = '(?:%s)' % '|'.join([str_strings, str_charlit, str_chrpair, str_complex])
+str_literal = '(?:%s)' % '|'.join([str_strings, str_charlit, str_chrpair, str_complex, str_intpair])
 str_litlist = '\[*' + str_literal + '(?:(?:\]*,\[*)' + str_literal + ')*' + '\]*'
 str_nonlits = '|'.join(map(re.escape, list(atoms) + list(quicks) + list(hypers)))
 


### PR DESCRIPTION
Makes the integers `[-31349,-100]` and `[1001,32250]` available as three byte literals.

The two bytes following `⁽` are evaluated as a base-250 number with digits of the 1-based code-page indexes. The top half of these are treated as negative numbers much like there being a sign bit. The lowest positive value, 1001, is `⁽¡¡`; the largest positive value, 32250, is `⁽|ż`; the lowest negative value, -31349, is `⁽}¡` (the next base 250 representation after `⁽|ż`); the largest negative value, -100, is `⁽żż`.

Note: There is still a little redundancy: the 30 positive multiples of 1000 [e.g. both `⁽/ż` and `13ȷ` are 13000], the smallest 9 negative multiples of 1000 [e.g. both `⁽ṛc` and `-7ȷ` are -7000], the 9 integers of the form 1000+500*n [e.g. both `⁽!ż` and `9.ȷ` are 9500], and -500 [`ẏc` and`-.ȷ`].