### PR TITLE
Allow floats as input to lowered range, `Ḷ`

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -1346,7 +1346,7 @@ atoms = {
 	'Ḷ': attrdict(
 		arity = 1,
 		ldepth = 0,
-		call = lambda z: list(range(z))
+		call = lambda z: list(range(int(z)))
 	),
 	'l': attrdict(
 		arity = 2,


### PR DESCRIPTION
Matching the implementation of `R`.