### PR TITLE
Added 'any' atom

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -1292,6 +1292,10 @@ atoms = {
 		arity = 1,
 		call = equal
 	),
+	'Ẹ': attrdict(
+		arity = 1,
+		call = lambda z: int(any(iterable(z)))
+	),
 	'Ė': attrdict(
 		arity = 1,
 		call = lambda z: [[t + 1, u] for t, u in enumerate(iterable(z))]

--- a/jelly.py
+++ b/jelly.py
@@ -2,7 +2,7 @@ import cmath, collections, copy, dictionary, fractions, functools, itertools, lo
 
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
-# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƤƬƲȤɗƒɦƙɱɲƥʠɼʂƭʋȥẸẈẒĿṘẎŻẹḥḳṇọụṿẉỵẓḋėġŀṅẏ
+# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƬƲȤɗƒɦƙɱɲƥʠɼʂƭʋȥẈẒŻẹḥḳṇụṿẉỵẓḋėġṅẏ
 
 str_digit = '0123456789'
 str_lower = 'abcdefghijklmnopqrstuvwxyz'


### PR DESCRIPTION
`Ẹ` would behave like `Ạ` but for `any` instead of `all`.

Test cases:

+ `[]` -> `0`
+ `[0]` -> `0`
+ `[0, 0, 0, [0], 0, 0]` -> `1`
+ `[1, 500, -1]` -> `1`
+ `[0, 0, [], 0]` -> `1` (?)