### PR TITLE
Implemented key (ƙ) quick

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -2,7 +2,7 @@ import cmath, collections, copy, dictionary, fractions, functools, itertools, lo
 
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
-# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƬƲȤɗƒɦƙɱɲƥʠɼʂƭʋȥẸẈẒŻẹḥḳṇụṿẉỵẓḋėġṅẏ
+# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƬƲȤɗƒɦɱɲƥʠɼʂƭʋȥẸẈẒŻẹḥḳṇụṿẉỵẓḋėġṅẏ
 
 str_digit = '0123456789'
 str_lower = 'abcdefghijklmnopqrstuvwxyz'
@@ -882,6 +882,22 @@ def split_fixed(array, width):
 def split_fixed_out(array, width):
 	array = iterable(array)
 	return [array[:index] + array[index + width:] for index in range(0, len(array), width)]
+
+def split_key(control, data):
+	groups = {}
+	order = []
+	count = 0
+	for key, item in zip(control, data):
+		key = repr(key) if type(key) == list else key
+		if key not in groups:
+			order.append(key)
+			groups[key] = []
+		groups[key].append(item)
+		count += 1
+	result = [groups[key] for key in order]
+	if count < len(data):
+		result.append(data[count:])
+	return result
 
 def split_once(array, needle):
 	array = iterable(array, make_digits = True)
@@ -2489,6 +2505,13 @@ quicks = {
 	'ÐƤ': attrdict(
 		condition = lambda links: links and links[0].arity,
 		quicklink = suffix
+	),
+	'ƙ': attrdict(
+		condition = lambda links: links and links[0].arity,
+		quicklink = lambda links, outmost_links, index: [attrdict(
+			arity = 2,
+			call = lambda x, y: [monadic_link(links[0], g) for g in split_key(iterable(x, make_digits = True), iterable(y, make_digits = True))]
+		)]
 	),
 	'¤': attrdict(
 		condition = lambda links: len(links) > 1 and links[0].arity == 0,


### PR DESCRIPTION
Another mapping quick based on J's [key](http://code.jsoftware.com/wiki/Vocabulary/slashdot#dyadic). 
Motivation: https://codegolf.stackexchange.com/q/139513/6710

Sample solution (based on J solution), 6 bytes:

    Æmṁ$ƙF