### PR TITLE
Added new links

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -3,7 +3,7 @@ import cmath, collections, copy, dictionary, fractions, functools, itertools, lo
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
 
-# Unused letters for single atoms: kquƁƇƘⱮƝƬȤɗƒɦɱƥʠɼʂʋȥẈẒŻẹḥḳṇụṿẉỵẓḋėġṅẏ
+# Unused letters for single atoms: kquƁƇƊƘⱮƝƬƲȤɗƒɦɱƥʠɼʂʋȥẹḥḳṇụṿẉỵẓḋėġṅẏ
 
 str_digit = '0123456789'
 str_lower = 'abcdefghijklmnopqrstuvwxyz'
@@ -1312,11 +1312,6 @@ atoms = {
 		arity = 1,
 		call = lambda z: iterable(z, make_range = True)[1:]
 	),
-	'Ɗ': attrdict(
-		arity = 1,
-		ldepth = 0,
-		call = lambda z: z - 2
-	),
 	'd': attrdict(
 		arity = 2,
 		ldepth = 0,
@@ -1648,11 +1643,6 @@ atoms = {
 		arity = 1,
 		call = lambda z: sorted(range(1, len(iterable(z)) + 1), key = lambda t: iterable(z)[t - 1])
 	),
-	'Ʋ': attrdict(
-		arity = 1,
-		ldepth = 0,
-		call = lambda z: z + 2
-	),
 	'V': attrdict(
 		arity = 1,
 		ldepth = 1,
@@ -1670,6 +1660,11 @@ atoms = {
 	'W': attrdict(
 		arity = 1,
 		call = lambda z: [z]
+	),
+	'Ẉ': attrdict(
+		arity = 1,
+		ldepth = 0,
+		call = lambda z: z - 2
 	),
 	'Ẇ': attrdict(
 		arity = 1,
@@ -1720,6 +1715,11 @@ atoms = {
 	'Z': attrdict(
 		arity = 1,
 		call = zip_ragged
+	),
+	'Ẓ': attrdict(
+		arity = 1,
+		ldepth = 0,
+		call = lambda z: z + 2
 	),
 	'Ż': attrdict(
 		arity = 1,

--- a/jelly.py
+++ b/jelly.py
@@ -1723,7 +1723,7 @@ atoms = {
 	),
 	'Ż': attrdict(
 		arity = 1,
-		call = lambda x: [list(i) for i in zip(*zip(*x))]
+		call = lambda x: [i[:min(map(len, x))] for i in x]
 	),
 	'z': attrdict(
 		arity = 2,

--- a/jelly.py
+++ b/jelly.py
@@ -1721,6 +1721,10 @@ atoms = {
 		arity = 1,
 		call = zip_ragged
 	),
+	'Ż': attrdict(
+		arity = 1,
+		call = lambda x: [list(i) for i in zip(*zip(*x))]
+	),
 	'z': attrdict(
 		arity = 2,
 		call = lambda x, y: listify(itertools.zip_longest(*map(iterable, x), fillvalue = y))

--- a/jelly.py
+++ b/jelly.py
@@ -1723,7 +1723,7 @@ atoms = {
 	),
 	'Ż': attrdict(
 		arity = 1,
-		call = lambda x: [i[:min(map(len, iterable(x)))] for i in x]
+		call = lambda x: [iterable(i)[:min(len(iterable(j)) for j in x)] for i in x]
 	),
 	'z': attrdict(
 		arity = 2,

--- a/jelly.py
+++ b/jelly.py
@@ -1723,7 +1723,7 @@ atoms = {
 	),
 	'Ż': attrdict(
 		arity = 1,
-		call = lambda x: [i[:min(map(len, x))] for i in x]
+		call = lambda x: [i[:min(map(len, iterable(x)))] for i in x]
 	),
 	'z': attrdict(
 		arity = 2,

--- a/jelly.py
+++ b/jelly.py
@@ -2461,7 +2461,7 @@ atoms = {
 	),
 	'Øƈ': attrdict(
 		arity = 0,
-		call = lambda: sys.stdin.read
+		call = sys.stdin.read
 	),
 	'Øe': attrdict(
 		arity = 0,

--- a/jelly.py
+++ b/jelly.py
@@ -1316,7 +1316,7 @@ atoms = {
 		arity = 1,
 		ldepth = 0,
 		call = lambda z: z - 2
-	)
+	),
 	'd': attrdict(
 		arity = 2,
 		ldepth = 0,
@@ -1652,7 +1652,7 @@ atoms = {
 		arity = 1,
 		ldepth = 0,
 		call = lambda z: z + 2
-	)
+	),
 	'V': attrdict(
 		arity = 1,
 		ldepth = 1,
@@ -2106,7 +2106,7 @@ atoms = {
 		arity = 1,
 		ldepth = 0,
 		call = lambda z: 2 ** z
-	)
+	),
 	'Œ!': attrdict(
 		arity = 1,
 		call = lambda z: listify(itertools.permutations(iterable(z, make_range = True)))
@@ -2211,6 +2211,10 @@ atoms = {
 		arity = 1,
 		ldepth = 2,
 		call = rld
+	),
+	'ŒṢ': attrdict(
+		arity = 1,
+		call = lambda z: sorted(iterable(z, make_digits = True), reverse = True)
 	),
 	'Œs': attrdict(
 		arity = 1,
@@ -2458,7 +2462,7 @@ atoms = {
 	'Øƈ': attrdict(
 		arity = 0,
 		call = lambda: sys.stdin.read
-	)
+	),
 	'Øe': attrdict(
 		arity = 0,
 		call = lambda: math.e
@@ -2512,7 +2516,7 @@ quicks = {
 	'ɲ': attrdict(
 		condition = lambda links: True,
 		quicklink = lambda links, outmost_links, index: [create_chain(outmost_links[(index + 1) % len(outmost_links)], 0)]
-	)
+	),
 	'Ñ': attrdict(
 		condition = lambda links: True,
 		quicklink = lambda links, outmost_links, index: [create_chain(outmost_links[(index + 1) % len(outmost_links)], 1)]
@@ -2714,7 +2718,7 @@ hypers = {
 	'ÐÞ': lambda link, none = None: attrdict(
 		arity = link.arity,
 		call = lambda x, y = None: sorted(x, key=lambda t:variadic_link(link, (t, y)), reverse=True)
-	)
+	),
 	'þ': lambda link, none = None: attrdict(
 		arity = 2,
 		call = lambda x, y: [[dyadic_link(link, (u, v)) for u in iterable(x, make_range = True)] for v in iterable(y, make_range = True)]

--- a/jelly.py
+++ b/jelly.py
@@ -3,7 +3,7 @@ import cmath, collections, copy, dictionary, fractions, functools, itertools, lo
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
 
-# Unused letters for single atoms: kquƁƇƊƑƘⱮƝƬƲȤɗƒɦɱɲƥʠɼʂʋȥẈẒŻẹḥḳṇụṿẉỵẓḋėġṅẏ
+# Unused letters for single atoms: kquƁƇƘⱮƝƬȤɗƒɦɱƥʠɼʂʋȥẈẒŻẹḥḳṇụṿẉỵẓḋėġṅẏ
 
 str_digit = '0123456789'
 str_lower = 'abcdefghijklmnopqrstuvwxyz'
@@ -1312,6 +1312,11 @@ atoms = {
 		arity = 1,
 		call = lambda z: iterable(z, make_range = True)[1:]
 	),
+	'Ɗ': attrdict(
+		arity = 1,
+		ldepth = 0,
+		call = lambda z: z - 2
+	)
 	'd': attrdict(
 		arity = 2,
 		ldepth = 0,
@@ -1643,6 +1648,11 @@ atoms = {
 		arity = 1,
 		call = lambda z: sorted(range(1, len(iterable(z)) + 1), key = lambda t: iterable(z)[t - 1])
 	),
+	'Ʋ': attrdict(
+		arity = 1,
+		ldepth = 0,
+		call = lambda z: z + 2
+	)
 	'V': attrdict(
 		arity = 1,
 		ldepth = 1,
@@ -2092,6 +2102,11 @@ atoms = {
 		ldepth = 1,
 		call = from_primorial_base
 	),
+	'Æ«': attrdict(
+		arity = 1,
+		ldepth = 0,
+		call = lambda z: 2 ** z
+	)
 	'Œ!': attrdict(
 		arity = 1,
 		call = lambda z: listify(itertools.permutations(iterable(z, make_range = True)))
@@ -2440,6 +2455,10 @@ atoms = {
 		arity = 0,
 		call = lambda: list('AEIOUaeiou')
 	),
+	'Øƈ': attrdict(
+		arity = 0,
+		call = lambda: sys.stdin.read
+	)
 	'Øe': attrdict(
 		arity = 0,
 		call = lambda: math.e
@@ -2490,6 +2509,10 @@ quicks = {
 		condition = lambda links: True,
 		quicklink = lambda links, outmost_links, index: [create_chain(outmost_links[index - 1], 2)]
 	),
+	'ɲ': attrdict(
+		condition = lambda links: True,
+		quicklink = lambda links, outmost_links, index: [create_chain(outmost_links[(index + 1) % len(outmost_links)], 0)]
+	)
 	'Ñ': attrdict(
 		condition = lambda links: True,
 		quicklink = lambda links, outmost_links, index: [create_chain(outmost_links[(index + 1) % len(outmost_links)], 1)]
@@ -2688,6 +2711,10 @@ hypers = {
 		arity = link.arity,
 		call = lambda x, y = None: sorted(x, key=lambda t: variadic_link(link, (t, y)))
 	),
+	'ÐÞ': lambda link, none = None: attrdict(
+		arity = link.arity,
+		call = lambda x, y = None: sorted(x, key=lambda t:variadic_link(link, (t, y)), reverse=True)
+	)
 	'þ': lambda link, none = None: attrdict(
 		arity = 2,
 		call = lambda x, y: [[dyadic_link(link, (u, v)) for u in iterable(x, make_range = True)] for v in iterable(y, make_range = True)]


### PR DESCRIPTION
Added a load of new links and quicks. Here is an explanation of each one:

+ `Ẓ`: **z + 2** (same as `+2$` or `‘‘$` or `‘⁺$` or `‘2¡`). (not sure about this one)
+ `Ẉ`: **z - 2** (same as `_2$` or `’’$` or `’⁺$` or `’2¡`). (not sure about this one too)
+ `Æ«`: **2<sup>z</sup>** or **1 << z** (same as `2*$`). (again not sure)
+ `Øƈ`: Get all input at once (no eval) (same as `“”;ƈ$ÐL¤`).
+ `ɲ`: Call next link as a nilad quick (same as `(link index + 1)£`).
+ `ÐÞ`: Reversed keyed sort quick (same as `ÞṚ(max arity ¤$¥ quick)`).
+ `ŒṢ`: Reversed sort (same as `ṢṚ$`).
+ `Ż`: Truncate to shortest length (same as `ḣ€L€Ṃ$$`).

(note: there might be bugs, although I've plucked some out already)

**EDIT**: I have improved the use of Jelly's naming conventions in this list. There might be a few problems because of the limited number of available single-byte tokens. Some may be:

+ The choice of `Ẓ` and `Ẉ` for +2 and -2, since they could also represent the inverses of `Z` and `W`. However, `Z` doesn't have an inverse due to auto-wrapping non-lists in a list and `W`'s single-byte inverse is `X`.