### PR TITLE
Regex Atoms

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -12,12 +12,17 @@ str_upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 inf = float('inf')
 nan = float('nan')
 sys.setrecursionlimit(1 << 30)
-
 class attrdict(dict):
 	def __init__(self, *args, **kwargs):
 		dict.__init__(self, *args, **kwargs)
 		self.__dict__ = self
 
+def to_string(k):
+	return ''.join(k) if is_string(k) else str(k)
+
+def func_a(x,links):
+	sub_function = lambda k: to_string(variadic_link(links[1],([k.group(0)]+list(k.groups()),k.span())))
+	return(list(re.sub(''.join(links[0].call()), sub_function, ''.join(map(str,x)))))
 def arities(links):
 	return [link.arity for link in links]
 
@@ -2355,6 +2360,41 @@ atoms = {
 		rdepth = 0,
 		call = lambda x, y: split_evenly(iterable(x, make_range = True), y)
 	),
+	'œF': attrdict(
+		arity = 2,
+		ldepth = 1,
+		rdepth = 1,
+		call = lambda x,y: re.findall(''.join(map(str,x)), ''.join(map(str,y)))
+	),
+	'œḞ': attrdict(
+		arity = 2,
+		ldepth = 1,
+		rdepth = 1,
+		call = lambda x,y: [[k.group(0)]+list(k.groups()) for k in re.finditer(''.join(map(str,x)), ''.join(map(str,y)))]
+	),
+	'œṠ': attrdict(
+		arity = 2,
+		ldepth = 2,
+		rdepth = 1,
+		call = lambda x,y: re.sub(''.join(''.join(map(str,x[0]))), ''.join(''.join(map(str,x[1]))), ''.join(''.join(map(str,y))))
+	),
+	'œR': attrdict(
+		arity = 2,
+		rdepth = 1,
+		ldepth = 1,
+		call = lambda x,y: bool(re.search(''.join(map(str,x)),''.join(map(str,y))))
+	),
+	'œṢ': attrdict(
+		arity = 2,
+		ldepth = 1,
+		rdepth = 1,
+		call = lambda x,y: re.split(''.join(map(str,x)),''.join(map(str,y)))
+	),
+	# findall: pattern, string                            # œF
+	# finditer: pattern, string => groups                 # œḞ
+	# re.sub                    => string                 # œṠ
+	# re.search                                           # œR
+	# re.split: pattern, string                           # œṢ
 	'œṡ': attrdict(
 		arity = 2,
 		rdepth = 0,
@@ -2655,6 +2695,13 @@ quicks = {
 		quicklink = lambda links, outmost_links, index: [attrdict(
 			arity = links[0].arity,
 			call = lambda x, y = None: extremes(max, links[0], (x, y))
+		)]
+	),
+	'ÐR': attrdict(
+		condition = lambda links: len(links) == 2,
+		quicklink = lambda links, outmost_links, index: [attrdict(
+			arity = 1,
+			call = lambda x: func_a(x, links)
 		)]
 	),
 }

--- a/jelly.py
+++ b/jelly.py
@@ -265,9 +265,17 @@ def simplest_number(number):
 		return float(number)
 	return int(number)
 
-def sub_quick(x,links):
+def sub_quick(string, links):
+	regexes = iterable(links[0].call())
+	regexes = [''.join(regexes)] if is_string(regexes) else [''.join(k) for k in regexes]
 	sub_function = lambda k: to_string(variadic_link(links[1],([k.group(0)]+list(k.groups()),k.span())))
-	return(list(re.sub(''.join(links[0].call()), sub_function, ''.join(map(str,x)))))
+	string = iterable(''.join(string), make_copy = True)
+	if depth(string) == 1:
+		for regex in regexes:
+			string = [re.sub(''.join(regex), sub_function,k) for k in string]
+	else:
+		string = [sub_quick(k, links) for k in string]
+	return string
 
 def get_request(url):
 	url = ''.join(map(str, url))
@@ -1013,6 +1021,16 @@ def translate(mapping, array):
 			if item in source:
 				array[index] = destination[min(source.index(item), len(destination) - 1)]
 	return array
+
+def translate_regex(mapping, string):
+	string = ''.join(string)
+	mapping = iterable(mapping, make_copy = True)
+	while mapping:
+		regexes = iterable(mapping.pop(0))
+		subs = iterable(mapping.pop(0))
+		for (index, regex) in enumerate(regexes):
+			string = re.sub(regex, subs[min(index,len(subs)-1)], string)
+	return string
 
 def trim(trimmee, trimmer, left = False, right = False):
 	lindex = 0
@@ -2378,7 +2396,7 @@ atoms = {
 		arity = 2,
 		ldepth = 2,
 		rdepth = 1,
-		call = lambda x,y: re.sub(''.join(''.join(map(str,x[0]))), ''.join(''.join(map(str,x[1]))), ''.join(''.join(map(str,y))))
+		call = translate_regex
 	),
 	'œR': attrdict(
 		arity = 2,

--- a/jelly.py
+++ b/jelly.py
@@ -1,4 +1,4 @@
-import cmath, collections, copy, dictionary, fractions, functools, itertools, locale, math, numpy, operator, parser, random, re, sympy, sys, time, urllib.request
+import cmath, collections, copy, dictionary, fractions, functools, itertools, locale, math, numpy, operator, random, re, sympy, sys, time, urllib.request
 
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭụṿẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
@@ -12,17 +12,12 @@ str_upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 inf = float('inf')
 nan = float('nan')
 sys.setrecursionlimit(1 << 30)
+
 class attrdict(dict):
 	def __init__(self, *args, **kwargs):
 		dict.__init__(self, *args, **kwargs)
 		self.__dict__ = self
 
-def to_string(k):
-	return ''.join(k) if is_string(k) else str(k)
-
-def func_a(x,links):
-	sub_function = lambda k: to_string(variadic_link(links[1],([k.group(0)]+list(k.groups()),k.span())))
-	return(list(re.sub(''.join(links[0].call()), sub_function, ''.join(map(str,x)))))
 def arities(links):
 	return [link.arity for link in links]
 
@@ -269,6 +264,10 @@ def simplest_number(number):
 	if number % 1:
 		return float(number)
 	return int(number)
+
+def sub_quick(x,links):
+	sub_function = lambda k: to_string(variadic_link(links[1],([k.group(0)]+list(k.groups()),k.span())))
+	return(list(re.sub(''.join(links[0].call()), sub_function, ''.join(map(str,x)))))
 
 def get_request(url):
 	url = ''.join(map(str, url))
@@ -1000,6 +999,9 @@ def tie(links, outmost_links, index):
 def time_format(bitfield):
 	time_string = ':'.join(['%H'] * (bitfield & 4 > 0) + ['%M'] * (bitfield & 2 > 0) + ['%S'] * (bitfield & 1 > 0))
 	return list(time.strftime(time_string))
+
+def to_string(k):
+	return ''.join(k) if is_string(k) else str(k)
 
 def translate(mapping, array):
 	array = iterable(array, make_copy = True)
@@ -2390,11 +2392,6 @@ atoms = {
 		rdepth = 1,
 		call = lambda x,y: re.split(''.join(map(str,x)),''.join(map(str,y)))
 	),
-	# findall: pattern, string                            # œF
-	# finditer: pattern, string => groups                 # œḞ
-	# re.sub                    => string                 # œṠ
-	# re.search                                           # œR
-	# re.split: pattern, string                           # œṢ
 	'œṡ': attrdict(
 		arity = 2,
 		rdepth = 0,
@@ -2701,7 +2698,7 @@ quicks = {
 		condition = lambda links: len(links) == 2,
 		quicklink = lambda links, outmost_links, index: [attrdict(
 			arity = 1,
-			call = lambda x: func_a(x, links)
+			call = lambda x: sub_quick(x, links)
 		)]
 	),
 }


### PR DESCRIPTION
 - `œF`: Regex Findall: Find all instances of regex `x` in string `y`; return a list of matches
 - `œḞ`: Regex Finditer: Find all instances of regex `x` in string `y`; return a list of lists of groups
 - `œṠ`: Regex Sub: Take arguments substitution configuration `[x1,x2]` and y. Substitute all instances of regex `x1` with replacement string `x2` in string `y`.
 - `œR`: Regex Search: Give a boolean denoting if regex `x` matches string `y` in any position.
 - `œṢ`: Regex Split: Split string `y` at occurrences of regex `x`.
 - `ÐR`: Regex sub quick: `<regex><sub>ÐR` replaces all occurrences of `<regex>` with `<sub>` applied to each occurrence’s list of groups and span

Some possible issues: 

 - If `œṠ` is given a left argument/configuration which is a string, it substitutes all instances of the first character of the string with the second character of the string in the right argument, which is the same as atom `y`.
 - `ÐR` uses `to_string(x) = ''.join(x) if is_string(x) else str(x)` to cast the output of `<sub>` to string. Not sure if there is a better casting method.

