### PR TITLE
Extended behavior of {

### DIFF
--- a/jelly.py
+++ b/jelly.py
@@ -2693,7 +2693,7 @@ hypers = {
 	),
 	'{': lambda link, none = None: attrdict(
 		arity = 2,
-		call = lambda x, y: monadic_link(link, x)
+		call = lambda x, y: dyadic_link(link, (y, y)) if link.arity == 2 else monadic_link(link, x)
 	),
 	'}': lambda link, none = None: attrdict(
 		arity = 2,


### PR DESCRIPTION
This pull request makes `(x)(dyad){(y)` to act like `(y)(dyad)(y)`. I [suggested it before](https://chat.stackexchange.com/transcript/message/43330445#43330445), but I went ahead and implemented it.

~Please test if it works before pulling. :wink:~ This has been tested, and is working perfectly.