### PR TITLE
Ðg - Apply link, get runs, mold original list based on them

### DIFF
--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -2936,6 +2936,13 @@ quicks = {
 			call = lambda x, y = None: list(itertools.filterfalse(lambda t: variadic_link(links[0], (t, y)), iterable(x, make_range = True)))
 		)]
 	),
+	'Ðg': attrdict(
+		condition = lambda links: links,
+		quicklink = lambda links, outmost_links, index: [attrdict(
+			arity = max(links[0].arity, 1),
+			call = lambda x, y = None: atoms['ṁ'].call(x, group_equal(variadic_link(links[0], (x, y))))
+		)]
+	),
 	'ÐL': attrdict(
 		condition = lambda links: links,
 		quicklink = lambda links, outmost_links, index: [attrdict(
@@ -2969,13 +2976,6 @@ quicks = {
 		quicklink = lambda links, outmost_links, index: [attrdict(
 			arity = links[0].arity,
 			call = lambda x, y = None: extremes(max, links[0], (x, y))
-		)]
-	),
-	'ÐG': attrdict(
-		condition = lambda links: links,
-		quicklink = lambda links, outmost_links, index: [attrdict(
-			arity = max(links[0].arity, 1),
-			call = lambda x, y = None: atoms['ṁ'].call(x, group_equal(variadic_link(link, (x, y))))
 		)]
 	)
 }

--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -2971,6 +2971,13 @@ quicks = {
 			call = lambda x, y = None: extremes(max, links[0], (x, y))
 		)]
 	),
+	'ÐG': attrdict(
+		condition = lambda links: links,
+		quicklink = lambda links, outmost_links, index: [attrdict(
+			arity = max(links[0].arity, 1),
+			call = lambda x, y = None: atoms['ṁ'].call(x, group_equal(variadic_link(link, (x, y))))
+		)]
+	)
 }
 
 hypers = {
@@ -3021,10 +3028,6 @@ hypers = {
 	'ŀ': lambda index, links: attrdict(
 		arity = 2,
 		call = lambda x, y: dyadic_chain(links[(variadic_link(index, (x, y)) - 1) % (len(links) - 1)], (x, y))
-	),
-	'Ðg': lambda link, none = None: attrdict(
-		arity = max(1, link.arity)
-		call = lambda x, y = None: atoms['ṁ'],call(x, group_equal(variadic_link(link, (x, y))))
 	)
 }
 

--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -3021,6 +3021,10 @@ hypers = {
 	'ŀ': lambda index, links: attrdict(
 		arity = 2,
 		call = lambda x, y: dyadic_chain(links[(variadic_link(index, (x, y)) - 1) % (len(links) - 1)], (x, y))
+	),
+	'Ðg': lambda link, none = None: attrdict(
+		arity = max(1, link.arity)
+		call = lambda x, y = None: atoms['ṁ'],call(x, group_equal(variadic_link(link, (x, y))))
 	)
 }
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
 	name = 'jellylanguage',
-	version = '0.1.21',
+	version = '0.1.22',
 	packages = [
 		'jelly'
 	],


### PR DESCRIPTION
Important notes:

+ Getting the runs is done by using the `group_equal` function directly, not based on the `Œg` atom's behavior.
+ Molding is done based on the `ṁ` atom's **call**.

**Note**: Please test this if you can, I don't have time right now.