### PR TITLE
Unique permutations, odd-even, group lengths

### DIFF
--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -2239,10 +2239,6 @@ atoms = {
 		arity = 1,
 		call = lambda z: jellify(itertools.permutations(iterable(z, make_range = True)))
 	),
-	'Œ¡': attrdict(
-		arity = 1,
-		call = lambda z: list(sympy.utilities.iterables.multiset_permutations(iterable(z, make_digits = True)))
-	),
 	'Œ?': attrdict(
 		arity = 1,
 		ldepth = 0,
@@ -2422,7 +2418,6 @@ atoms = {
 	),
 	'Œɠ': attrdict(
 		arity = 1,
-		ldepth = 1,
 		call = group_lengths
 	),
 	'œ?': attrdict(

--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -352,6 +352,18 @@ def group_equal(array):
 			groups.append([x])
 	return groups
 
+def group_lengths(array):
+	array = iterable(array, make_digits = True)
+	lengths = []
+	previous_item = None
+	for x in array:
+		if lengths and previous_item == x:
+			lengths[-1] += 1
+		else:
+			lengths.append(1)
+		previous_item = x
+	return lengths
+
 def identity(argument):
 	return argument
 
@@ -2240,10 +2252,6 @@ atoms = {
 		arity = 1,
 		call = permutation_index
 	),
-	'Œœ': attrdict(
-		arity = 1,
-		call = odd_even
-	),
 	'ŒB': attrdict(
 		arity = 1,
 		ldepth = 1,
@@ -2407,6 +2415,15 @@ atoms = {
 		arity = 1,
 		ldepth = 1,
 		call = lambda z: to_case(z, upper = True)
+	),
+	'Œœ': attrdict(
+		arity = 1,
+		call = odd_even
+	),
+	'Œɠ': attrdict(
+		arity = 1,
+		ldepth = 1,
+		call = group_lengths
 	),
 	'œ?': attrdict(
 		arity = 2,

--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -667,6 +667,10 @@ def ntimes(links, args, cumulative = False):
 		rarg = larg
 	return cumret + [ret] if cumulative else ret
 
+def odd_even(array):
+	array = iterable(array, make_range = True)
+	return [[t for t in array[::2]], [t for t in array[1::2]]]
+
 def order(number, divisor):
 	if number == 0 or abs(divisor) == 1:
 		return inf
@@ -2223,6 +2227,10 @@ atoms = {
 		arity = 1,
 		call = lambda z: jellify(itertools.permutations(iterable(z, make_range = True)))
 	),
+	'Œ¡': attrdict(
+		arity = 1,
+		call = lambda z: list(sympy.utilities.iterables.multiset_permutations(iterable(z, make_digits = True)))
+	),
 	'Œ?': attrdict(
 		arity = 1,
 		ldepth = 0,
@@ -2231,6 +2239,10 @@ atoms = {
 	'Œ¿': attrdict(
 		arity = 1,
 		call = permutation_index
+	),
+	'Œœ': attrdict(
+		arity = 1,
+		call = odd_even
 	),
 	'ŒB': attrdict(
 		arity = 1,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
 	name = 'jellylanguage',
-	version = '0.1.21',
+	version = '0.1.22',
 	packages = [
 		'jelly'
 	],


### PR DESCRIPTION
<s>`Œ¡` unique permutations. Uses sympy's multiset permutations built-in.</s>
`Œœ` Odd-even. Same as `s2Z`.
`Œɠ` Group lengths. <s>Same as `ŒgL€`.</s> Unlike `Œg`, this does not vectorize. If the argument is an integer, the lengths of groups of it's consecutive digits will be found.

Two details I wasn't sure about:

- Should `Œœ` vectorize? If so, at what depth?
- `Œg` makes a call to `iterable(array, make_digits = True)`, but because `ldepth = 1`, applying it to an integer never causes it to be converted to decimal. I included the same call to `iterable` in `Œɠ` and specified `ldepth = 1` to be consistent, but I think it would be more useful if `ldepth` was `0` or if the atom didn't vectorize.