### PR TITLE
Fixed a bug with œṡ

### DIFF
--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -1013,11 +1013,9 @@ def split_key(control, data):
 	return result
 
 def split_once(array, needle):
-	if needle not in array:
-		return [array]
 	array = iterable(array, make_digits = True)
-	index = index_of(array, needle) or len(array)
-	return [array[0 : index - 1], array[index :]]
+	index = index_of(array, needle)
+	return [array[0 : index - 1], array[index :]] if index else [array]
 
 def split_prefix(array):
 	array = iterable(array)

--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -1013,6 +1013,8 @@ def split_key(control, data):
 	return result
 
 def split_once(array, needle):
+	if needle not in array:
+		return [array]
 	array = iterable(array, make_digits = True)
 	index = index_of(array, needle) or len(array)
 	return [array[0 : index - 1], array[index :]]


### PR DESCRIPTION
Previously, `œṡ` had a weird behaviour if **y** didn't occur in **x**. That is, it discarded the last element and wrapped the result in a list along with an empty list at the end (i.e. `[x[:-1], []]`). Now, it just returns `[x]`, which seems more intuitive. Let me know if this causes any issues / the old behaviour is intended.