### PR TITLE
Make the default return value when reducing empty lists be an empty list.

### DIFF
--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -924,6 +924,8 @@ def reduce(links, outmost_links, index, arity = 1):
 
 def reduce_simple(array, link, *init):
 	array = iterable(array)
+	if len(array) == 0 and len(init) == 0:
+		return []
 	return functools.reduce(lambda x, y: dyadic_link(link, (x, y)), array, *init)
 
 def reduce_cumulative(links, outmost_links, index):


### PR DESCRIPTION
When reducing an empty list with no initial values specified return an empty list rather than raising a TypeError ("reduce() of empty sequence with no initial value"). I believe this is a nicer default behaviour for Jelly to have.