### PR TITLE
Add the ʂ nilad which gets all command line arguments as an array.

### DIFF
--- a/jelly/__init__.py
+++ b/jelly/__init__.py
@@ -6,6 +6,8 @@ def main(code, args, end):
 	for index in range(min(7, len(args))):
 		atoms['³⁴⁵⁶⁷⁸⁹'[index]].call = lambda literal = args[index]: literal
 
+	atoms['ʂ'].call = lambda: args
+
 	try:
 		output(jelly_eval(code, args[:2]), end)
 	except KeyboardInterrupt:

--- a/jelly/interpreter.py
+++ b/jelly/interpreter.py
@@ -7,7 +7,7 @@ random, sympy, urllib_request = lazy_import('random sympy urllib.request')
 code_page  = '''¡¢£¤¥¦©¬®µ½¿€ÆÇÐÑ×ØŒÞßæçðıȷñ÷øœþ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~¶'''
 code_page += '''°¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ƁƇƊƑƓƘⱮƝƤƬƲȤɓƈɗƒɠɦƙɱɲƥʠɼʂƭʋȥẠḄḌẸḤỊḲḶṂṆỌṚṢṬỤṾẈỴẒȦḂĊḊĖḞĠḢİĿṀṄȮṖṘṠṪẆẊẎŻạḅḍẹḥịḳḷṃṇọṛṣṭ§Äẉỵẓȧḃċḋėḟġḣŀṁṅȯṗṙṡṫẇẋẏż«»‘’“”'''
 
-# Unused symbols for single-byte atoms/quicks: (quƁƘȤɦɱɲƥʠʂȥḥḳṇẉỵẓėġṅẏ
+# Unused symbols for single-byte atoms/quicks: (quƁƘȤɦɱɲƥʠȥḥḳṇẉỵẓėġṅẏ
 
 str_digit = '0123456789'
 str_lower = 'abcdefghijklmnopqrstuvwxyz'
@@ -1753,6 +1753,10 @@ atoms = {
 	'ṣ': attrdict(
 		arity = 2,
 		call = lambda x, y: jellify(split_at(iterable(x, make_digits = True), y))
+	),
+	'ʂ': attrdict(
+		arity = 0,
+		call = lambda: []
 	),
 	'T': attrdict(
 		arity = 1,


### PR DESCRIPTION
This follows the convention that hooked letters represent nilads. For example, ɠ reads from STDIN.

For example, to treats all command line arguments as numbers and outputs the sum of their squares: ʂ²+/